### PR TITLE
Now using local babel-cli and using it for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/sch1sch/less-plugin-jspm-import"
   },
   "scripts": {
-    "build": "babel --optional runtime src -d lib",
+    "build": "node ./node_modules/babel-cli/bin/babel.js --optional runtime src -d lib",
     "prepublish": "npm run-script build",
     "preinstall": "npm run-script build"
   },
@@ -35,6 +35,7 @@
     "less": "^2.0"
   },
   "devDependencies": {
-    "babel": "^5.8.29"
+    "babel": "^5.8.29",
+    "babel-cli": "^6.18.0"
   }
 }


### PR DESCRIPTION
For now we should use local babel cli to build the plugin
